### PR TITLE
Fix doc

### DIFF
--- a/docs/generate.php
+++ b/docs/generate.php
@@ -251,12 +251,6 @@ class BuilderParser
      */
     private function prepareBuilderFromClass(ReflectionClass $class): void
     {
-        $parentClass = $class->getParentClass();
-
-        if (false !== $parentClass) {
-            $this->prepareBuilderFromClass($parentClass);
-        }
-
         $classPhpDoc = $this->parsePhpDoc($class->getDocComment() ?: '');
         $defaultPackage = $classPhpDoc['package'] ?? null;
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -303,10 +303,10 @@ class BuilderParser
             }
 
             if (isset($parsedDocBlock['tags']['see'])) {
-                $this->parts['methods']['@'][$method->getShortName()]['tags']['see'] = array_unique(array_merge(
+                $this->parts['methods']['@'][$method->getShortName()]['tags']['see'] = array_unique(array_map('trim', array_merge(
                     $this->parts['methods']['@'][$method->getShortName()]['tags']['see'] ?? [],
                     $parsedDocBlock['tags']['see'],
-                ));
+                )));
             }
         }
     }

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -257,14 +257,6 @@ class BuilderParser
             $this->prepareBuilderFromClass($parentClass);
         }
 
-        foreach ($class->getInterfaces() as $interface) {
-            $this->prepareBuilderFromClass($interface);
-        }
-
-        foreach ($class->getTraits() as $trait) {
-            $this->prepareBuilderFromClass($trait);
-        }
-
         $classPhpDoc = $this->parsePhpDoc($class->getDocComment() ?: '');
         $defaultPackage = $classPhpDoc['package'] ?? null;
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -3,97 +3,14 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#html-file-into-pdf-route](https://gotenberg.dev/docs/routes#html-file-into-pdf-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### forwardCookie(string $name)
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### landscape(bool $bool)
-Set the paper orientation to landscape.
-
-### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.
 
 ### metadata(array $metadata)
 Resets the metadata.<br />
@@ -103,23 +20,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-### nativePageRanges(string $ranges)
-Page ranges to print, e.g., '1-5, 8, 11-13'.
-
-### omitBackground(bool $bool)
-Hide the default white background and allow generating PDFs with transparency.
-
-### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -127,20 +28,6 @@ Convert the resulting PDF into the given PDF/A format.
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS.
-
-### printBackground(bool $bool)
-Prints the background graphics.
-
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0).
-
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages.
 
@@ -150,20 +37,11 @@ Either the intervals or the page ranges to extract, depending on the selected mo
 ### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -183,3 +61,125 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF.
+
+### landscape(bool $bool)
+Set the paper orientation to landscape.
+
+### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.
+
+### nativePageRanges(string $ranges)
+Page ranges to print, e.g., '1-5, 8, 11-13'.
+
+### omitBackground(bool $bool)
+Hide the default white background and allow generating PDFs with transparency.
+
+### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS.
+
+### printBackground(bool $bool)
+Prints the background graphics.
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0).
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -3,72 +3,79 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#html-file-into-pdf-route](https://gotenberg.dev/docs/routes#html-file-into-pdf-route)
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### metadata(array $metadata)
-Resets the metadata.<br />
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
-> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
-> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
-> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
-### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
-Convert the resulting PDF into the given PDF/A format.
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
-### pdfUniversalAccess(bool $bool)
-Enable PDF for Universal Access for optimal accessibility.
-
-### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
-Either intervals or pages.
-
-### splitSpan(string $splitSpan)
-Either the intervals or the page ranges to extract, depending on the selected mode.
-
-### splitUnify(bool $bool)
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
-
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### webhook(array $webhook)
 > [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-### webhookConfiguration(string $name)
-Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
-### webhookErrorRoute(string $route, array $parameters, ?string $method)
-### webhookErrorUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-### webhookExtraHeaders(array $extraHttpHeaders)
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
 
-### webhookRoute(string $route, array $parameters, ?string $method)
-### webhookUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
 
-### cookies(array $cookies)
+### footerFile(string $path)
+HTML file containing the footer.
+
 ### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
 
 ### landscape(bool $bool)
 Set the paper orientation to landscape.
@@ -88,6 +95,16 @@ Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6p
 ### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.
 
+### metadata(array $metadata)
+Resets the metadata.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
+> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
+> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
+> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 ### nativePageRanges(string $ranges)
 Page ranges to print, e.g., '1-5, 8, 11-13'.
 
@@ -104,6 +121,12 @@ Overrides the default paper size, in inches.<br /><br />Examples of paper size (
 ### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
 
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
+Convert the resulting PDF into the given PDF/A format.
+
+### pdfUniversalAccess(bool $bool)
+Enable PDF for Universal Access for optimal accessibility.
+
 ### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS.
 
@@ -113,8 +136,22 @@ Prints the background graphics.
 ### scale(float $scale)
 The scale of the page rendering (e.g., 1.0).
 
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
+Either intervals or pages.
+
+### splitSpan(string $splitSpan)
+Either the intervals or the page ranges to extract, depending on the selected mode.
+
+### splitUnify(bool $bool)
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
 
 ### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
@@ -128,58 +165,21 @@ Sets the JavaScript expression to wait before converting an HTML document to PDF
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### footer(string $template, array $context)
+### webhook(array $webhook)
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-### footerFile(string $path)
-HTML file containing the footer.
+### webhookConfiguration(string $name)
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+### webhookErrorRoute(string $route, array $parameters, ?string $method)
+### webhookErrorUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### headerFile(string $path)
-HTML file containing the header.
+### webhookExtraHeaders(array $extraHttpHeaders)
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+### webhookRoute(string $route, array $parameters, ?string $method)
+### webhookUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -20,7 +20,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -126,7 +126,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -150,19 +150,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -83,7 +83,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 ### nativePageRanges(string $ranges)
 Page ranges to print, e.g., '1-4' - empty means all pages.<br />

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -83,7 +83,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### nativePageRanges(string $ranges)
 Page ranges to print, e.g., '1-4' - empty means all pages.<br />

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -3,99 +3,20 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
 ### files(Stringable|string ...$paths)
 Add Markdown into a PDF.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route](https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route)
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### forwardCookie(string $name)
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### landscape(bool $bool)
-Set the paper orientation to landscape.
-
-### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.
 
 ### metadata(array $metadata)
 Resets the metadata.<br />
@@ -105,23 +26,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-### nativePageRanges(string $ranges)
-Page ranges to print, e.g., '1-5, 8, 11-13'.
-
-### omitBackground(bool $bool)
-Hide the default white background and allow generating PDFs with transparency.
-
-### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -129,20 +34,6 @@ Convert the resulting PDF into the given PDF/A format.
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS.
-
-### printBackground(bool $bool)
-Prints the background graphics.
-
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0).
-
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages.
 
@@ -152,20 +43,15 @@ Either the intervals or the page ranges to extract, depending on the selected mo
 ### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
+### wrapper(string $template, array $context)
+### wrapperFile(string $path)
+The HTML file to convert into PDF.
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -185,7 +71,121 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### wrapper(string $template, array $context)
-### wrapperFile(string $path)
-The HTML file to convert into PDF.
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
 
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF.
+
+### landscape(bool $bool)
+Set the paper orientation to landscape.
+
+### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.
+
+### nativePageRanges(string $ranges)
+Page ranges to print, e.g., '1-5, 8, 11-13'.
+
+### omitBackground(bool $bool)
+Hide the default white background and allow generating PDFs with transparency.
+
+### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS.
+
+### printBackground(bool $bool)
+Prints the background graphics.
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0).
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -3,14 +3,57 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 ### files(Stringable|string ...$paths)
 Add Markdown into a PDF.<br />
@@ -18,67 +61,23 @@ Add Markdown into a PDF.<br />
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route](https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route)
 
-### metadata(array $metadata)
-Resets the metadata.<br />
-
+### footer(string $template, array $context)
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
-> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
-> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
-> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
 
-### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
-Convert the resulting PDF into the given PDF/A format.
+### footerFile(string $path)
+HTML file containing the footer.
 
-### pdfUniversalAccess(bool $bool)
-Enable PDF for Universal Access for optimal accessibility.
-
-### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
-Either intervals or pages.
-
-### splitSpan(string $splitSpan)
-Either the intervals or the page ranges to extract, depending on the selected mode.
-
-### splitUnify(bool $bool)
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
-
-### wrapper(string $template, array $context)
-### wrapperFile(string $path)
-The HTML file to convert into PDF.
-
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### webhook(array $webhook)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-### webhookConfiguration(string $name)
-Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-### webhookErrorRoute(string $route, array $parameters, ?string $method)
-### webhookErrorUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
-
-### webhookExtraHeaders(array $extraHttpHeaders)
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-### webhookRoute(string $route, array $parameters, ?string $method)
-### webhookUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### cookies(array $cookies)
 ### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
 
 ### landscape(bool $bool)
 Set the paper orientation to landscape.
@@ -98,6 +97,16 @@ Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6p
 ### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.
 
+### metadata(array $metadata)
+Resets the metadata.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
+> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
+> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
+> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 ### nativePageRanges(string $ranges)
 Page ranges to print, e.g., '1-5, 8, 11-13'.
 
@@ -114,6 +123,12 @@ Overrides the default paper size, in inches.<br /><br />Examples of paper size (
 ### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
 
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
+Convert the resulting PDF into the given PDF/A format.
+
+### pdfUniversalAccess(bool $bool)
+Enable PDF for Universal Access for optimal accessibility.
+
 ### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS.
 
@@ -123,8 +138,22 @@ Prints the background graphics.
 ### scale(float $scale)
 The scale of the page rendering (e.g., 1.0).
 
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
+Either intervals or pages.
+
+### splitSpan(string $splitSpan)
+Either the intervals or the page ranges to extract, depending on the selected mode.
+
+### splitUnify(bool $bool)
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
 
 ### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
@@ -138,58 +167,25 @@ Sets the JavaScript expression to wait before converting an HTML document to PDF
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
-### content(string $template, array $context)
-### contentFile(string $path)
+### webhook(array $webhook)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
+### webhookConfiguration(string $name)
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+### webhookErrorRoute(string $route, array $parameters, ?string $method)
+### webhookErrorUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+
+### webhookExtraHeaders(array $extraHttpHeaders)
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
+
+### webhookRoute(string $route, array $parameters, ?string $method)
+### webhookUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+
+### wrapper(string $template, array $context)
+### wrapperFile(string $path)
 The HTML file to convert into PDF.
 
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -26,7 +26,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -136,7 +136,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -160,19 +160,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -31,7 +31,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -31,7 +31,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -26,7 +26,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -26,7 +26,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -3,83 +3,79 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### metadata(array $metadata)
-Resets the metadata.<br />
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
-> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
-> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
-> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
-### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
-Convert the resulting PDF into the given PDF/A format.
-
-### pdfUniversalAccess(bool $bool)
-Enable PDF for Universal Access for optimal accessibility.
-
-### route(string $name, array $parameters)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
-
-### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
-### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
-Either intervals or pages.
-
-### splitSpan(string $splitSpan)
-Either the intervals or the page ranges to extract, depending on the selected mode.
-
-### splitUnify(bool $bool)
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
-
-### url(string $url)
-URL of the page you want to convert into PDF.<br />
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### webhook(array $webhook)
 > [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-### webhookConfiguration(string $name)
-Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
 
-### webhookErrorRoute(string $route, array $parameters, ?string $method)
-### webhookErrorUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-### webhookExtraHeaders(array $extraHttpHeaders)
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
 
-### webhookRoute(string $route, array $parameters, ?string $method)
-### webhookUrl(string $url, ?string $method)
-Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+### footerFile(string $path)
+HTML file containing the footer.
 
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### cookies(array $cookies)
 ### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
 
 ### landscape(bool $bool)
 Set the paper orientation to landscape.
@@ -99,6 +95,16 @@ Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6p
 ### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.
 
+### metadata(array $metadata)
+Resets the metadata.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)<br />
+> See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
+> See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
+> See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 ### nativePageRanges(string $ranges)
 Page ranges to print, e.g., '1-5, 8, 11-13'.
 
@@ -115,17 +121,48 @@ Overrides the default paper size, in inches.<br /><br />Examples of paper size (
 ### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
 
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
+Convert the resulting PDF into the given PDF/A format.
+
+### pdfUniversalAccess(bool $bool)
+Enable PDF for Universal Access for optimal accessibility.
+
 ### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS.
 
 ### printBackground(bool $bool)
 Prints the background graphics.
 
+### route(string $name, array $parameters)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
+
 ### scale(float $scale)
 The scale of the page rendering (e.g., 1.0).
 
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
 ### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
+Either intervals or pages.
+
+### splitSpan(string $splitSpan)
+Either the intervals or the page ranges to extract, depending on the selected mode.
+
+### splitUnify(bool $bool)
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+### url(string $url)
+URL of the page you want to convert into PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
 
 ### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
@@ -139,58 +176,21 @@ Sets the JavaScript expression to wait before converting an HTML document to PDF
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### footer(string $template, array $context)
+### webhook(array $webhook)
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-### footerFile(string $path)
-HTML file containing the footer.
+### webhookConfiguration(string $name)
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+### webhookErrorRoute(string $route, array $parameters, ?string $method)
+### webhookErrorUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### headerFile(string $path)
-HTML file containing the header.
+### webhookExtraHeaders(array $extraHttpHeaders)
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+### webhookRoute(string $route, array $parameters, ?string $method)
+### webhookUrl(string $url, ?string $method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -3,97 +3,14 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### forwardCookie(string $name)
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### landscape(bool $bool)
-Set the paper orientation to landscape.
-
-### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.
 
 ### metadata(array $metadata)
 Resets the metadata.<br />
@@ -103,23 +20,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-### nativePageRanges(string $ranges)
-Page ranges to print, e.g., '1-5, 8, 11-13'.
-
-### omitBackground(bool $bool)
-Hide the default white background and allow generating PDFs with transparency.
-
-### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
-
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -127,25 +28,11 @@ Convert the resulting PDF into the given PDF/A format.
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS.
-
-### printBackground(bool $bool)
-Prints the background graphics.
-
 ### route(string $name, array $parameters)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0).
-
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages.
 
@@ -161,20 +48,11 @@ URL of the page you want to convert into PDF.<br />
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -194,3 +72,125 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF.
+
+### landscape(bool $bool)
+Set the paper orientation to landscape.
+
+### marginBottom(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify bottom margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginLeft(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify left margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginRight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify right margin using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### marginTop(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify top margin width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.
+
+### nativePageRanges(string $ranges)
+Page ranges to print, e.g., '1-5, 8, 11-13'.
+
+### omitBackground(bool $bool)
+Hide the default white background and allow generating PDFs with transparency.
+
+### paperHeight(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper height using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $value, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Specify paper width using units like 72pt, 96px, 1in, 25.4mm, 2.54cm, or 6pc. Default unit is inches if unspecified.
+
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS.
+
+### printBackground(bool $bool)
+Prints the background graphics.
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0).
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -20,7 +20,7 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-libreoffice](https://gotenberg.dev/docs/routes#metadata-libreoffice)<br />
 > See: [https://gotenberg.dev/docs/routes#write-pdf-metadata-route](https://gotenberg.dev/docs/routes#write-pdf-metadata-route)<br />
 > See: [https://gotenberg.dev/docs/routes#merge-pdfs-route](https://gotenberg.dev/docs/routes#merge-pdfs-route)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
 
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
@@ -137,7 +137,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -161,19 +161,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -70,7 +70,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -94,19 +94,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -3,17 +3,108 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### forwardCookie(string $name)
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### skipNetworkIdleEvent(bool $bool)
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -33,97 +124,6 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### cookies(array $cookies)
-### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -3,108 +3,17 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### forwardCookie(string $name)
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### skipNetworkIdleEvent(bool $bool)
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -124,6 +33,97 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -3,57 +3,11 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 ### files(Stringable|string ...$paths)
 Add Markdown into a PDF.<br />
@@ -61,52 +15,15 @@ Add Markdown into a PDF.<br />
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route](https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route)
 
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+### wrapper(string $template, array $context)
+### wrapperFile(string $path)
+The HTML file to convert into PDF.
 
-### footerFile(string $path)
-HTML file containing the footer.
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### forwardCookie(string $name)
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### skipNetworkIdleEvent(bool $bool)
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -126,10 +43,93 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
-### wrapper(string $template, array $context)
-### wrapperFile(string $path)
-The HTML file to convert into PDF.
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -80,7 +80,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -104,19 +104,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -3,11 +3,57 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 ### files(Stringable|string ...$paths)
 Add Markdown into a PDF.<br />
@@ -15,15 +61,52 @@ Add Markdown into a PDF.<br />
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route](https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route)
 
-### wrapper(string $template, array $context)
-### wrapperFile(string $path)
-The HTML file to convert into PDF.
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
+### footerFile(string $path)
+HTML file containing the footer.
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### forwardCookie(string $name)
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### skipNetworkIdleEvent(bool $bool)
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -43,97 +126,10 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### cookies(array $cookies)
-### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### content(string $template, array $context)
-### contentFile(string $path)
+### wrapper(string $template, array $context)
+### wrapperFile(string $path)
 The HTML file to convert into PDF.
 
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,118 +1,27 @@
 # UrlScreenshotBuilder
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### forwardCookie(string $name)
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
 ### route(string $name, array $parameters)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
-### skipNetworkIdleEvent(bool $bool)
 ### url(string $url)
 URL of the page you want to convert into PDF.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -132,6 +41,97 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### cookies(array $cookies)
+### forwardCookie(string $name)
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,27 +1,118 @@
 # UrlScreenshotBuilder
 
+### addAsset(Stringable|string $path)
+Adds a file, like an image, font, stylesheet, and so on.
+
+### addCookies(array $cookies)
+Add cookies to store in the Chromium cookie jar.<br />
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
+
+### assets(Stringable|string ...$paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.
+
+### cookies(array $cookies)
 ### downloadFrom(array $downloadFrom)
 Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from](https://gotenberg.dev/docs/routes#download-from)
 
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
+### footer(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### footerFile(string $path)
+HTML file containing the footer.
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).
+
+### forwardCookie(string $name)
+### header(string $template, array $context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
+
+### headerFile(string $path)
+HTML file containing the header.
+
+### height(int $height)
+The device screen width in pixels. (Default 600).
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with transparency.
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
 ### route(string $name, array $parameters)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
+### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
 ### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
+### skipNetworkIdleEvent(bool $bool)
 ### url(string $url)
 URL of the page you want to convert into PDF.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#url-into-pdf-route](https://gotenberg.dev/docs/routes#url-into-pdf-route)
 
-### addAsset(Stringable|string $path)
-Adds a file, like an image, font, stylesheet, and so on.
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header.<br />
 
-### assets(Stringable|string ...$paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### webhook(array $webhook)
 > [!TIP]
@@ -41,97 +132,6 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 ### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
-### addCookies(array $cookies)
-Add cookies to store in the Chromium cookie jar.<br />
-
-### cookies(array $cookies)
-### forwardCookie(string $name)
-### setCookie(string $name, Symfony\Component\HttpFoundation\Cookie|array $cookie)
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).
-
-### height(int $height)
-The device screen width in pixels. (Default 600).
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with transparency.
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
 ### width(int $width)
 The device screen width in pixels. (Default 800).
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
-
-### footer(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### footerFile(string $path)
-HTML file containing the footer.
-
-### header(string $template, array $context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#header-footer-chromium](https://gotenberg.dev/docs/routes#header-footer-chromium)
-
-### headerFile(string $path)
-HTML file containing the header.
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML document.<br />
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML document. (overrides any previous headers).<br />
-
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header.<br />
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").
-
-### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -78,7 +78,7 @@ Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />do
 Sets the JavaScript expression to wait before converting an HTML document to PDF until it returns true.<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering-chromium](https://gotenberg.dev/docs/routes#wait-before-rendering-chromium)
 
 ### content(string $template, array $context)
 ### contentFile(string $path)
@@ -102,19 +102,19 @@ HTML file containing the header.
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#console-exceptions-chromium](https://gotenberg.dev/docs/routes#console-exceptions-chromium)
 
 ### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable. (overrides any previous configuration).<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium)
 
 ### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if Chromium fails to load at least one resource.<br />(default false).<br />

--- a/src/Builder/Behaviors/Chromium/FailOnTrait.php
+++ b/src/Builder/Behaviors/Chromium/FailOnTrait.php
@@ -65,7 +65,7 @@ trait FailOnTrait
      * Forces GotenbergPdf to return a 409 Conflict response if there are
      * exceptions in the Chromium console. (default false).
      *
-     * @see https://gotenberg.dev/docs/routes#console-exceptions
+     * @see https://gotenberg.dev/docs/routes#console-exceptions-chromium
      */
     #[ExposeSemantic(new BooleanNodeBuilder('fail_on_console_exceptions'))]
     public function failOnConsoleExceptions(bool $bool = true): static

--- a/src/Builder/Behaviors/Chromium/WaitBeforeRenderingTrait.php
+++ b/src/Builder/Behaviors/Chromium/WaitBeforeRenderingTrait.php
@@ -34,7 +34,7 @@ trait WaitBeforeRenderingTrait
      *
      * For instance: "window.status === 'ready'".
      *
-     * @see https://gotenberg.dev/docs/routes#wait-before-rendering
+     * @see https://gotenberg.dev/docs/routes#wait-before-rendering-chromium
      */
     #[ExposeSemantic(new ScalarNodeBuilder('wait_for_expression'))]
     public function waitForExpression(string $expression): static

--- a/src/Builder/Pdf/MarkdownPdfBuilder.php
+++ b/src/Builder/Pdf/MarkdownPdfBuilder.php
@@ -21,6 +21,8 @@ final class MarkdownPdfBuilder extends AbstractBuilder implements BuilderAssetIn
     use ChromiumPdfTrait {
         content as wrapper;
         contentFile as wrapperFile;
+        content as private;
+        contentFile as private;
     }
 
     public const ENDPOINT = '/forms/chromium/convert/markdown';
@@ -43,19 +45,6 @@ final class MarkdownPdfBuilder extends AbstractBuilder implements BuilderAssetIn
         $this->getBodyBag()->set('files', $files ?? null);
 
         return $this;
-    }
-
-    /**
-     * @param array<string, mixed> $context
-     */
-    public function content(string $template, array $context = []): void
-    {
-        throw new \BadMethodCallException('Use wrapper() instead of content().');
-    }
-
-    public function contentFile(string $path): void
-    {
-        throw new \BadMethodCallException('Use wrapperFile() instead of contentFile().');
     }
 
     protected function getEndpoint(): string

--- a/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
+++ b/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
@@ -21,6 +21,8 @@ final class MarkdownScreenshotBuilder extends AbstractBuilder implements Builder
     use ChromiumScreenshotTrait {
         content as wrapper;
         contentFile as wrapperFile;
+        content as private;
+        contentFile as private;
     }
 
     public const ENDPOINT = '/forms/chromium/screenshot/markdown';
@@ -43,19 +45,6 @@ final class MarkdownScreenshotBuilder extends AbstractBuilder implements Builder
         $this->getBodyBag()->set('files', $files ?? null);
 
         return $this;
-    }
-
-    /**
-     * @param array<string, mixed> $context
-     */
-    public function content(string $template, array $context = []): void
-    {
-        throw new \BadMethodCallException('Use wrapper() instead of content().');
-    }
-
-    public function contentFile(string $path): void
-    {
-        throw new \BadMethodCallException('Use wrapperFile() instead of contentFile().');
     }
 
     protected function getEndpoint(): string


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix https://github.com/sensiolabs/GotenbergBundle/pull/153#discussion_r2040667480 |

## Description

* Trim links to remove trailing space
* Hide `content` and `contentFile` unsupported methods of Markdown builders